### PR TITLE
toy algorithm

### DIFF
--- a/shared_anniez/alg/moer.py
+++ b/shared_anniez/alg/moer.py
@@ -1,0 +1,57 @@
+# moer.py
+
+import numpy as np 
+class Moer: 
+    def __init__(self, mu, isDiagonal=True, Sigma=None, sig2=0., ac1=None, ra=None): 
+        self.mu = np.array(mu).flatten()
+        self.ra = ra if ra is not None else 0.
+        self.__diagonal = isDiagonal
+        self.__T = self.mu.shape[0]
+        if (not self.__diagonal): 
+            if Sigma is not None: 
+                assert(Sigma.shape == (self.__T, self.__T))
+                self.Sigma = Sigma
+            elif ac1 is not None: 
+                from scipy.linalg import toeplitz
+                x = np.logspace(0, self.__T, base = ac1)
+                self.Sigma = toeplitz(x, x) * np.diag(sig2)
+        elif isinstance(sig2, float): 
+            self.Sigma = np.array([sig2] * self.__T)
+        else: 
+            self.Sigma = np.array(sig2).flatten()
+
+    def setRA(self, ra):
+        self.ra = ra
+
+    def length(self):
+        return self.__T
+    
+    def isDiagonal(self):
+        return self.__diagonal
+    
+    def getMarginalCost(self, xi, i): 
+        return self.mu[i] * xi
+
+    def getUnitUtil(self, xi, i, ra): 
+        return self.getMarginalCost(xi, i) + ra * self.Sigma[i] * xi**2
+    
+    def getMarginalUtil(self, xi, i, x_old=None, ra=None):
+        if ra is None:
+            ra = self.ra
+        if self.__diagonal: 
+            return self.getUnitUtil(xi, i, ra)
+        else: 
+            return self.getMarginalCost(xi, i) + ra * (2 * xi * self.Sigma[i,:i]@x_old[:i] + self.Sigma[i,i] * xi**2), np.hstack((x_old, xi))
+        
+    def getTotalCost(self, x): 
+        x = np.array(x).flatten()
+        return np.dot(self.mu, x)
+    
+    def getTotalUtil(self, x, ra=None): 
+        if ra is None:
+            ra = self.ra
+        x = np.array(x).flatten()
+        if self.__diagonal: 
+            return self.getTotalCost(x) + self.ra * np.multiply(self.Sigma, x**2).sum()
+        else: 
+            return self.getTotalCost(x) + self.ra * x.reshape((1,-1))@self.Sigma@x

--- a/shared_anniez/alg/moer.py
+++ b/shared_anniez/alg/moer.py
@@ -2,28 +2,30 @@
 
 import numpy as np 
 class Moer: 
-    def __init__(self, mu, isDiagonal=True, Sigma=None, sig2=0., ac1=None, ra=None): 
+    def __init__(self, mu, isDiagonal=False, Sigma=None, sig2=0., ac1=None, ra=None): 
         self.mu = np.array(mu).flatten()
         self.ra = ra if ra is not None else 0.
         self.__diagonal = isDiagonal
         self.__T = self.mu.shape[0]
+        if isinstance(sig2, float): 
+            sig2 = np.array([sig2] * self.__T)
+        else: 
+            sig2 = np.array(sig2).flatten()
         if (not self.__diagonal): 
             if Sigma is not None: 
                 assert(Sigma.shape == (self.__T, self.__T))
                 self.Sigma = Sigma
             elif ac1 is not None: 
                 from scipy.linalg import toeplitz
-                x = np.logspace(0, self.__T, base = ac1)
+                x = ac1**np.arange(0,self.__T)
                 self.Sigma = toeplitz(x, x) * np.diag(sig2)
-        elif isinstance(sig2, float): 
-            self.Sigma = np.array([sig2] * self.__T)
         else: 
-            self.Sigma = np.array(sig2).flatten()
+            self.Sigma = sig2
 
     def setRA(self, ra):
         self.ra = ra
 
-    def length(self):
+    def __len__(self):
         return self.__T
     
     def isDiagonal(self):
@@ -32,14 +34,16 @@ class Moer:
     def getMarginalCost(self, xi, i): 
         return self.mu[i] * xi
 
-    def getUnitUtil(self, xi, i, ra): 
+    def getUnitUtil(self, xi, i, ra=None): 
+        if ra is None:
+            ra = self.ra
         return self.getMarginalCost(xi, i) + ra * self.Sigma[i] * xi**2
     
     def getMarginalUtil(self, xi, i, x_old=None, ra=None):
         if ra is None:
             ra = self.ra
         if self.__diagonal: 
-            return self.getUnitUtil(xi, i, ra)
+            return self.getUnitUtil(xi, i, ra), x_old
         else: 
             return self.getMarginalCost(xi, i) + ra * (2 * xi * self.Sigma[i,:i]@x_old[:i] + self.Sigma[i,i] * xi**2), np.hstack((x_old, xi))
         

--- a/shared_anniez/alg/optCharger.py
+++ b/shared_anniez/alg/optCharger.py
@@ -19,7 +19,7 @@ class OptCharger:
         startChargeCost = 0,
         keepChargeCost = 0,
         stopChargeCost = 0,
-        constraints = []
+        constraints = {}
     ): 
         self.totalCharge = totalCharge
         self.moer = moer
@@ -34,74 +34,99 @@ class OptCharger:
         self.keepChargeCost = keepChargeCost
         self.stopChargeCost = stopChargeCost
         self.constraints = constraints
+        self.__optimalCost = None
+        self.__optimalChargingSchedule = None
     
-    def fit(self, get_schedule = True): 
-        # minUtil[{0..totalCharge},{0,1}] = cost (with risk penalty)
+    def diagonalFit(self): 
+        # maxUtil[{0..totalCharge},{0,1}] = cost (with risk penalty)
         # path[t,{0..totalCharge},{0,1},:] = [charge,{0,1]}]
-        minUtil = initNP((self.totalCharge+1,2))
-        minUtil[0,0] = 0.
-        pathHistory = initNP((self.moer.length(),self.totalCharge+1,2,2),0).astype(int)
-        for t in range(1,self.moer.length()+1): 
+        maxUtil = initNP((self.totalCharge+1,2))
+        maxUtil[0,0] = 0.
+        pathHistory = initNP((len(self.moer),self.totalCharge+1,2,2),0).astype(int)
+        for t in range(1,len(self.moer)+1): 
+            if t in self.constraints: 
+                minCharge, maxCharge = self.constraints[t]
+                minCharge = 0 if minCharge is None else max(0, minCharge)
+                maxCharge = self.totalCharge if maxCharge is None else min(maxCharge, self.totalCharge)
+            else: 
+                minCharge, maxCharge = 0, self.totalCharge
             # print("=== Time step", t, "===")
-            newMinUtil = initNP(minUtil.shape)
-            for c in range(0,self.totalCharge+1): 
+            newMaxUtil = initNP(maxUtil.shape)
+            for c in range(minCharge,maxCharge+1): 
                 ## update (c,0)
                 # print("-- charge", c, "| charging off --")
                 initVal = True
-                if not np.isnan(minUtil[c,0]): 
-                    newMinUtil[c,0] = minUtil[c,0]
+                if not np.isnan(maxUtil[c,0]): 
+                    newMaxUtil[c,0] = maxUtil[c,0]
                     pathHistory[t-1,c,0,:] = [c,0]
                     initVal = False
-                if not np.isnan(minUtil[c,1]): 
-                    newUtil = minUtil[c,1] + self.stopChargeCost 
-                    if initVal or (newUtil < newMinUtil[c,0]): 
-                        newMinUtil[c,0] = newUtil
+                if not np.isnan(maxUtil[c,1]): 
+                    newUtil = maxUtil[c,1] + self.stopChargeCost 
+                    if initVal or (newUtil > newMaxUtil[c,0]): 
+                        newMaxUtil[c,0] = newUtil
                         pathHistory[t-1,c,0,:] = [c,1]
 
                 ## update (c,1)
                 # print("-- charge", c, "| charging on --")
                 initVal = True
                 for ct in range(self.minChargeRate,min(c,self.maxChargeRate)+1):
-                    marg_util = self.moer.getMarginalUtil(ct, t-1)
-                    if (not np.isnan(minUtil[c-ct,0])): 
-                        newUtil = minUtil[c-ct,0] + self.startChargeCost + self.keepChargeCost + marg_util
-                        if initVal or (newUtil < newMinUtil[c,1]): 
-                            newMinUtil[c,1] = newUtil
+                    marg_util,_ = self.moer.getMarginalUtil(ct, t-1)
+                    if (not np.isnan(maxUtil[c-ct,0])): 
+                        newUtil = maxUtil[c-ct,0] - self.startChargeCost - self.keepChargeCost - marg_util
+                        if initVal or (newUtil > newMaxUtil[c,1]): 
+                            newMaxUtil[c,1] = newUtil
                             pathHistory[t-1,c,1,:] = [c-ct,0]
                         initVal = False
-                    if (not np.isnan(minUtil[c-ct,1])): 
-                        newUtil = minUtil[c-ct,1] + self.keepChargeCost + marg_util
-                        if initVal or (newUtil < newMinUtil[c,1]): 
-                            newMinUtil[c,1] = newUtil
+                    if (not np.isnan(maxUtil[c-ct,1])): 
+                        newUtil = maxUtil[c-ct,1] - self.keepChargeCost - marg_util
+                        if initVal or (newUtil > newMaxUtil[c,1]): 
+                            newMaxUtil[c,1] = newUtil
                             pathHistory[t-1,c,1,:] = [c-ct,1]
                         initVal = False
-            minUtil = newMinUtil
-            
+            maxUtil = newMaxUtil
+            # print(maxUtil)
+
         initVal = True
-        if not np.isnan(minUtil[c,0]): 
-            self.minUtil = minUtil[c,0]
+        if not np.isnan(maxUtil[c,0]): 
+            max_util = maxUtil[c,0]
             m_final = 0
             initVal = False
-        if not np.isnan(minUtil[c,1]): 
-            newUtil = minUtil[c,1] + self.stopChargeCost 
-            if initVal or (newUtil < self.minUtil): 
-                self.minUtil = newUtil
+        if not np.isnan(maxUtil[c,1]): 
+            newUtil = maxUtil[c,1] - self.stopChargeCost 
+            if initVal or (newUtil > max_util): 
+                max_util = newUtil
                 m_final = 1
-        if get_schedule: 
-            curr_state, t_curr = [c, m_final], self.moer.length()
-            schedule = []        
+            initVal = False
+        if initVal: 
+            raise Exception("Solution not found!")
+        curr_state, t_curr = [c, m_final], len(self.moer)
+        schedule = []        
+        schedule.append(curr_state)
+        while (t_curr > 0): 
+            curr_state = pathHistory[t_curr-1, curr_state[0], curr_state[1], :]
             schedule.append(curr_state)
-            while (t_curr > 0): 
-                curr_state = pathHistory[t_curr-1, curr_state[0], curr_state[1], :]
-                schedule.append(curr_state)
-                t_curr -= 1
-        self.optimalPath = np.array(schedule)[::-1,:]
-        self.optimalChargingSchedule = np.diff(self.optimalPath[:,0])
-        self.optimalCost = self.moer.getTotalCost(self.optimalChargingSchedule)
+            t_curr -= 1
+        self.__optimalUtil = max_util
+        self.__optimalPath = np.array(schedule)[::-1,:]
+        self.__optimalChargingSchedule = np.diff(self.__optimalPath[:,0])
+        self.__optimalCost = self.moer.getTotalCost(self.__optimalChargingSchedule)
+    
+    def fit(self): 
+        if self.moer.isDiagonal(): 
+            self.diagonalFit()
+        else: 
+            raise Exception("Not implemented!")
+            pass
+    
+    def getCost(self): 
+        return self.__optimalCost
+    
+    def getSchedule(self): 
+        return self.__optimalChargingSchedule
 
     def summary(self): 
-        print("Minimum carbon utility %.2f" % self.minUtil)
-        print("Expected carbon cost %.2f" % self.optimalCost)
-        print("Optimal charging schedule:", self.optimalChargingSchedule)
+        print("Optimal utility %.2f" % -self.__optimalUtil)
+        print("Expected emissions %.2f" % self.__optimalCost)
+        print("Optimal charging schedule:", self.__optimalChargingSchedule)
 
 

--- a/shared_anniez/alg/optCharger.py
+++ b/shared_anniez/alg/optCharger.py
@@ -1,0 +1,107 @@
+# optCharger.py
+import numpy as np
+from .moer import Moer
+
+def initNP(shape,val=np.nan): 
+    a = np.empty(shape)
+    a.fill(val)
+    return a
+
+class OptCharger: 
+    def __init__(
+        self, 
+        totalCharge, 
+        moer, 
+        # contiguousWindow = False, 
+        fixedChargeRate = None, 
+        minChargeRate = None, 
+        maxChargeRate = None,
+        startChargeCost = 0,
+        keepChargeCost = 0,
+        stopChargeCost = 0,
+        constraints = []
+    ): 
+        self.totalCharge = totalCharge
+        self.moer = moer
+        # self.contiguousWindow = contiguousWindow
+        if fixedChargeRate is not None: 
+            self.minChargeRate = fixedChargeRate
+            self.maxChargeRate = fixedChargeRate
+        else: 
+            self.minChargeRate = minChargeRate
+            self.maxChargeRate = maxChargeRate
+        self.startChargeCost = startChargeCost
+        self.keepChargeCost = keepChargeCost
+        self.stopChargeCost = stopChargeCost
+        self.constraints = constraints
+    
+    def fit(self, get_schedule = True): 
+        # minUtil[{0..totalCharge},{0,1}] = cost (with risk penalty)
+        # path[t,{0..totalCharge},{0,1},:] = [charge,{0,1]}]
+        minUtil = initNP((self.totalCharge+1,2))
+        minUtil[0,0] = 0.
+        pathHistory = initNP((self.moer.length(),self.totalCharge+1,2,2),0).astype(int)
+        for t in range(1,self.moer.length()+1): 
+            # print("=== Time step", t, "===")
+            newMinUtil = initNP(minUtil.shape)
+            for c in range(0,self.totalCharge+1): 
+                ## update (c,0)
+                # print("-- charge", c, "| charging off --")
+                initVal = True
+                if not np.isnan(minUtil[c,0]): 
+                    newMinUtil[c,0] = minUtil[c,0]
+                    pathHistory[t-1,c,0,:] = [c,0]
+                    initVal = False
+                if not np.isnan(minUtil[c,1]): 
+                    newUtil = minUtil[c,1] + self.stopChargeCost 
+                    if initVal or (newUtil < newMinUtil[c,0]): 
+                        newMinUtil[c,0] = newUtil
+                        pathHistory[t-1,c,0,:] = [c,1]
+
+                ## update (c,1)
+                # print("-- charge", c, "| charging on --")
+                initVal = True
+                for ct in range(self.minChargeRate,min(c,self.maxChargeRate)+1):
+                    marg_util = self.moer.getMarginalUtil(ct, t-1)
+                    if (not np.isnan(minUtil[c-ct,0])): 
+                        newUtil = minUtil[c-ct,0] + self.startChargeCost + self.keepChargeCost + marg_util
+                        if initVal or (newUtil < newMinUtil[c,1]): 
+                            newMinUtil[c,1] = newUtil
+                            pathHistory[t-1,c,1,:] = [c-ct,0]
+                        initVal = False
+                    if (not np.isnan(minUtil[c-ct,1])): 
+                        newUtil = minUtil[c-ct,1] + self.keepChargeCost + marg_util
+                        if initVal or (newUtil < newMinUtil[c,1]): 
+                            newMinUtil[c,1] = newUtil
+                            pathHistory[t-1,c,1,:] = [c-ct,1]
+                        initVal = False
+            minUtil = newMinUtil
+            
+        initVal = True
+        if not np.isnan(minUtil[c,0]): 
+            self.minUtil = minUtil[c,0]
+            m_final = 0
+            initVal = False
+        if not np.isnan(minUtil[c,1]): 
+            newUtil = minUtil[c,1] + self.stopChargeCost 
+            if initVal or (newUtil < self.minUtil): 
+                self.minUtil = newUtil
+                m_final = 1
+        if get_schedule: 
+            curr_state, t_curr = [c, m_final], self.moer.length()
+            schedule = []        
+            schedule.append(curr_state)
+            while (t_curr > 0): 
+                curr_state = pathHistory[t_curr-1, curr_state[0], curr_state[1], :]
+                schedule.append(curr_state)
+                t_curr -= 1
+        self.optimalPath = np.array(schedule)[::-1,:]
+        self.optimalChargingSchedule = np.diff(self.optimalPath[:,0])
+        self.optimalCost = self.moer.getTotalCost(self.optimalChargingSchedule)
+
+    def summary(self): 
+        print("Minimum carbon utility %.2f" % self.minUtil)
+        print("Expected carbon cost %.2f" % self.optimalCost)
+        print("Optimal charging schedule:", self.optimalChargingSchedule)
+
+

--- a/shared_anniez/notes.txt
+++ b/shared_anniez/notes.txt
@@ -1,13 +1,12 @@
 2024/6/8
 Added a toy algorithm that
 - inputs: 
-    - mandatory: total carbon charge, expected carbon forecast 
-    - optional: min/max/fixed charge per time period, covariance matrix of carbon forecast, additional cost for starting, maintaining and stopping charging
+    - mandatory: total carbon charge, expected moer forecast 
+    - optional: min/max/fixed charge per time period, full covariance matrix of moer forecast error, additional cost for starting, maintaining and stopping charging
 - outputs: optimal schedule, carbon cost, carbon "utility" (with uncertainty)
-next steps: 
-- impose constraints such as 
-    - "must reach 90% of goal within first three hours" 
-    - contiguity: currently achievable by imposing large "fake" cost for starting and stopping charge, but algorithm can be further optimized if we only want one period
+
+Next steps: 
+- impose contiguity constraints: currently achievable by imposing large "fake" cost for starting and stopping charge, but algorithm can be further optimized if we only want one period
 - more flexibility in measuring carbon cost. add layer that includes carbon cost and startup/shutdown cost, but no uncertainty
 - add framework for testing this on small data example
-- under strong non diagonal covariance structures, optimality isn't guaranteed
+- need to implement algorithm for nondiagonal errors covariance 

--- a/shared_anniez/notes.txt
+++ b/shared_anniez/notes.txt
@@ -1,0 +1,11 @@
+Added a toy algorithm that
+- inputs: 
+    - mandatory: total carbon charge, expected carbon forecast 
+    - optional: min/max/fixed charge per time period, covariance matrix of carbon forecast, additional cost for starting, maintaining and stopping charging
+- outputs: optimal schedule, carbon cost, carbon "utility" (with uncertainty)
+next steps: 
+- impose constraints such as 
+    - "must reach 90% of goal within first three hours" 
+    - contiguity: currently achievable by imposing large "fake" cost for starting and stopping charge, but algorithm can be further optimized if we only want one period
+- more flexibility in measuring carbon cost. add layer that includes carbon cost and startup/shutdown cost, but no uncertainty
+- add framework for testing this on small data example

--- a/shared_anniez/notes.txt
+++ b/shared_anniez/notes.txt
@@ -1,3 +1,4 @@
+2024/6/8
 Added a toy algorithm that
 - inputs: 
     - mandatory: total carbon charge, expected carbon forecast 
@@ -9,3 +10,4 @@ next steps:
     - contiguity: currently achievable by imposing large "fake" cost for starting and stopping charge, but algorithm can be further optimized if we only want one period
 - more flexibility in measuring carbon cost. add layer that includes carbon cost and startup/shutdown cost, but no uncertainty
 - add framework for testing this on small data example
+- under strong non diagonal covariance structures, optimality isn't guaranteed

--- a/shared_anniez/test.py
+++ b/shared_anniez/test.py
@@ -1,0 +1,24 @@
+from alg import optCharger, moer
+
+m = moer.Moer(
+    mu = [10,10,10,13,3], 
+    sig2 = 1.0,
+    ac1 = 0.9, 
+    ra = 0.
+)
+# print(m.length())
+# print(m.isDiagonal())
+# print(m.getMarginalCost(2,3))
+# print(m.getTotalCost([0,0,0,1,1]))
+# print(m.getTotalUtil([0,2,0,1,1]))
+
+model = optCharger.OptCharger(
+    totalCharge = 5, 
+    moer = m, 
+    minChargeRate = 1,
+    maxChargeRate = 2,
+    startChargeCost = 15,
+    keepChargeCost = 1,
+)
+model.fit()
+model.summary()

--- a/shared_anniez/test.py
+++ b/shared_anniez/test.py
@@ -2,23 +2,25 @@ from alg import optCharger, moer
 
 m = moer.Moer(
     mu = [10,10,10,13,3], 
+    isDiagonal = True,
     sig2 = 1.0,
-    ac1 = 0.9, 
+    # ac1 = 0.9, 
     ra = 0.
 )
-# print(m.length())
+print(len(m))
 # print(m.isDiagonal())
 # print(m.getMarginalCost(2,3))
 # print(m.getTotalCost([0,0,0,1,1]))
 # print(m.getTotalUtil([0,2,0,1,1]))
 
 model = optCharger.OptCharger(
-    totalCharge = 5, 
+    totalCharge = 10, 
     moer = m, 
     minChargeRate = 1,
-    maxChargeRate = 2,
-    startChargeCost = 15,
-    keepChargeCost = 1,
+    maxChargeRate = 4,
+    startChargeCost = 0,
+    keepChargeCost = 0,
+    constraints = {2:(5,None)}
 )
 model.fit()
 model.summary()


### PR DESCRIPTION
Sorry my last pull request went to the wrong place...

2024/6/8
Added a toy algorithm that
- inputs: 
    - mandatory: total carbon charge, expected moer forecast 
    - optional: min/max/fixed charge per time period, full covariance matrix of moer forecast error, additional cost for starting, maintaining and stopping charging
- outputs: optimal schedule, carbon cost, carbon "utility" (with uncertainty)

Next steps: 
- impose contiguity constraints: currently achievable by imposing large "fake" cost for starting and stopping charge, but algorithm can be further optimized if we only want one period
- more flexibility in measuring carbon cost. add layer that includes carbon cost and startup/shutdown cost, but no uncertainty
- add framework for testing this on small data example
- need to implement algorithm for nondiagonal errors covariance 