### PR TITLE
rename algorithms and allow not using all contiguous intervals

### DIFF
--- a/watttime/api.py
+++ b/watttime/api.py
@@ -592,6 +592,8 @@ class WattTimeOptimizer(WattTimeForecast):
             Uncertainty in usage time, in minutes.
         charge_per_interval : list, default=None
             The minimium and maximum (inclusive) charging amount per interval. If int instead of tuple, interpret as both min and max.
+        use_all_intervals : bool
+            If true, use all intervals provided by charge_per_interval; if false, can use the first few intervals and skip the rest. 
         optimization_method : Optional[Literal["baseline", "simple", "sophisticated", "auto"]], default="baseline"
             The method used for optimization.
         moer_data_override : Optional[pd.DataFrame], default=None

--- a/watttime/api_test.py
+++ b/watttime/api_test.py
@@ -1,3 +1,4 @@
+# /bin/python3 -m watttime.api_test /home/annie.zhu/watttime-python-client-aer-algo/watttime/api_test.py 
 import os
 import time
 from datetime import date, datetime, timedelta
@@ -82,7 +83,7 @@ dp_usage_plan_4 = wt_opt.get_optimal_usage_plan(
     usage_window_start=window_start_test,
     usage_window_end=window_end_test,
     usage_time_required_minutes=7,
-    usage_power_kw=usage_power_kw,
+    usage_power_kw=usage_power_kw_df,
     optimization_method="auto",
 )
 print(dp_usage_plan_4)
@@ -102,21 +103,8 @@ dp_usage_plan_5 = wt_opt.get_optimal_usage_plan(
 print(dp_usage_plan_5["usage"].tolist())
 print(dp_usage_plan_5.sum())
 
-print("Using auto mode, but constrained to two contiguous intervals with length constraints")
+print("Using auto mode, but constrained to two contiguous intervals with fixed length constraints")
 dp_usage_plan_6 = wt_opt.get_optimal_usage_plan(
-    region=region,
-    usage_window_start=window_start_test,
-    usage_window_end=window_end_test,
-    usage_time_required_minutes=160,
-    usage_power_kw=usage_power_kw,
-    charge_per_interval=[(60,100),(60,100)],
-    optimization_method="auto",
-)
-print(dp_usage_plan_6["usage"].tolist())
-print(dp_usage_plan_6.sum())
-
-print("Using auto mode, but constrained to two contiguous intervals with length constraints")
-dp_usage_plan_7 = wt_opt.get_optimal_usage_plan(
     region=region,
     usage_window_start=window_start_test,
     usage_window_end=window_end_test,
@@ -125,5 +113,32 @@ dp_usage_plan_7 = wt_opt.get_optimal_usage_plan(
     charge_per_interval=[60,100],
     optimization_method="auto",
 )
+print(dp_usage_plan_6["usage"].tolist())
+print(dp_usage_plan_6.sum())
+
+print("Using auto mode, but constrained to two contiguous intervals with variable length constraints")
+dp_usage_plan_7 = wt_opt.get_optimal_usage_plan(
+    region=region,
+    usage_window_start=window_start_test,
+    usage_window_end=window_end_test,
+    usage_time_required_minutes=160,
+    usage_power_kw=usage_power_kw,
+    charge_per_interval=[(60,100),(60,100)],
+    optimization_method="auto",
+)
 print(dp_usage_plan_7["usage"].tolist())
 print(dp_usage_plan_7.sum())
+
+print("Using auto mode, but constrained to two contiguous intervals with variable length constraints, and doesn't need to use all intervals")
+dp_usage_plan_8 = wt_opt.get_optimal_usage_plan(
+    region=region,
+    usage_window_start=window_start_test,
+    usage_window_end=window_end_test,
+    usage_time_required_minutes=160,
+    usage_power_kw=usage_power_kw,
+    charge_per_interval=[(40,None)]*4,
+    use_all_intervals=False,
+    optimization_method="auto",
+)
+print(dp_usage_plan_8["usage"].tolist())
+print(dp_usage_plan_8.sum())

--- a/watttime/optimizer/test_new.py
+++ b/watttime/optimizer/test_new.py
@@ -1,11 +1,11 @@
 from alg import moer, optCharger
+model = optCharger.OptCharger()
 
 m = moer.Moer(
     mu = [10,10,10,1,13,3,2,3], 
 )
 print("Length of schedule:", len(m))
 
-model = optCharger.OptCharger()
 print("greedy algo")
 model.fit(totalCharge=3, totalTime=8, moer=m, optimization_method='baseline'); model.summary()
 print("simple sorting algo")
@@ -37,16 +37,27 @@ model.fit(totalCharge=3, totalTime=8, moer=m, charge_per_interval=[(2,2),(1,1)],
 print ("Two contiguous intervals + variable power rate + constraints")
 model.fit(totalCharge=4, totalTime=8, moer=m, charge_per_interval=[3,1], constraints = {2:(None,1),5:(3,None)}); model.summary()
 
-# # Variable Contiguous
-# print("One contiguous interval")
-# model.fit(totalCharge=3, totalTime=8, moer=m, charge_per_interval=[(0,3)]); model.summary()
-# print("Two contiguous intervals")
-# model.fit(totalCharge=3, totalTime=8, moer=m, charge_per_interval=[(1,2),(0,3)]); model.summary()
-# print ("Two contiguous intervals + variable power rate")
-# model.fit(totalCharge=3, totalTime=8, moer=m, charge_per_interval=[(1,2),(1,2)], emission_multiplier_fn=lambda x,y: [1.0,0.1,1.0][x]); model.summary()
-# print ("Two contiguous intervals + variable power rate")
-# model.fit(totalCharge=4, totalTime=8, moer=m, charge_per_interval=[(1,3),(0,3)]); model.summary()
-# print ("Two contiguous intervals + variable power rate + constraints")
-# model.fit(totalCharge=4, totalTime=8, moer=m, charge_per_interval=[(1,3),(0,3)], constraints = {2:(None,1)}); model.summary()
-# print ("Two contiguous intervals + variable power rate + constraints")
-# model.fit(totalCharge=4, totalTime=8, moer=m, charge_per_interval=[(1,3),(0,3)], constraints = {2:(None,1),5:(3,None)}); model.summary()
+# Variable Contiguous
+print("One contiguous interval")
+model.fit(totalCharge=3, totalTime=8, moer=m, charge_per_interval=[(0,3)]); model.summary()
+print("Two contiguous intervals")
+model.fit(totalCharge=3, totalTime=8, moer=m, charge_per_interval=[(1,2),(0,3)]); model.summary()
+print ("Two contiguous intervals + variable power rate")
+model.fit(totalCharge=3, totalTime=8, moer=m, charge_per_interval=[(1,2),(1,2)], emission_multiplier_fn=lambda x,y: [1.0,0.1,1.0][x]); model.summary()
+print ("Two contiguous intervals + variable power rate")
+model.fit(totalCharge=4, totalTime=8, moer=m, charge_per_interval=[(1,3),(0,3)]); model.summary()
+print ("Two contiguous intervals + variable power rate + constraints")
+model.fit(totalCharge=4, totalTime=8, moer=m, charge_per_interval=[(1,3),(0,3)], constraints = {2:(None,1)}); model.summary()
+print ("Two contiguous intervals + variable power rate + constraints")
+model.fit(totalCharge=4, totalTime=8, moer=m, charge_per_interval=[(1,3),(0,3)], constraints = {2:(None,1),5:(3,None)}); model.summary()
+
+m = moer.Moer(
+    mu = [10,1,1,1,10,1,1,1], 
+)
+print ("Three contiguous intervals of fixed lengths")
+model.fit(totalCharge=6, totalTime=8, moer=m, charge_per_interval=[2]*3); model.summary()
+print ("Three contiguous intervals of variable lengths")
+model.fit(totalCharge=6, totalTime=8, moer=m, charge_per_interval=[(2,6)]*3); model.summary()
+print ("Three contiguous intervals of variable lengths, but doesnt need to charge all intervals")
+model.fit(totalCharge=6, totalTime=8, moer=m, charge_per_interval=[(2,6)]*3, use_all_intervals=False); model.summary()
+


### PR DESCRIPTION
- Rename the two contiguous algorithm functions
- Added option to not use all contiguous variables. For instance, suppose I want to charge for a total of 100 mins, and i require (30,100),(30,100),(30,100). If I don't have to use all intervals, then 100=50+50 is allowed; otherwise it isn't. 
- Updated test and api_test to check these changes. 